### PR TITLE
add --no-color option to ARGS

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ cd "$WORKING_DIR" || exit
 ARGS=(
   "$@"
    --config "$CONFIG_ABS_PATH"
+   --no-colors 
 )
 
 # 'check' sub-command doesn't require credentials


### PR DESCRIPTION
--no-color is a new argument added in StackExchange/dnscontrol#2507 This will fix color char codes being sent to STDOUT and captured